### PR TITLE
feat: add option to skip artifact upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ jobs:
           OUTPUT_APP_NAME: "Output_app_name" - Optional, will also apply for second output universal apk  - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
           FIREBASE_APP_ID: - Optional (required for Crashlytics) - App ID in Firebase project
           DATADOG_API_KEY: - Data Dog API_KEY (required for DataDog Deobfuscation)
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 
 ### Android - PRIVATE_SIGNING
@@ -71,6 +72,7 @@ jobs:
           OUTPUT_APP_NAME: "Output_app_name" - Optional, will also apply for second output universal apk  - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
           FIREBASE_APP_ID: - Optional (required for Crashlytics) - App ID in Firebase project
           DATADOG_API_KEY: - Data Dog API_KEY (required for DataDog Deobfuscation)****
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 
 ### Android - AUTO_DEV_SIGNING
@@ -101,6 +103,7 @@ jobs:
           OUTPUT_APP_NAME: "Output_app_name" - Optional - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
           FIREBASE_APP_ID: - Optional (required for Crashlytics) - App ID in Firebase project
           DATADOG_API_KEY: - Data Dog API_KEY (required for DataDog Deobfuscation)
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 
 ### iOS - AUTO_SIGNING
@@ -136,6 +139,7 @@ jobs:
           BUILD_WITH_LOGS: true - Optional
           BUILD_TO_TEST: "lambdatest" | "bitbar" | "browserstack" | "saucelabs" | "perfecto" | "tosca" | "aws_device_farm" | "firebase" | "kobiton" | "katalon" | "None" - Optional - since version 1.1.0
           OUTPUT_APP_NAME: "Output_app_name" - Optional - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 
 ### iOS - PRIVATE_SIGNING
@@ -168,6 +172,7 @@ jobs:
           BUILD_WITH_LOGS: true - Optional
           BUILD_TO_TEST: "lambdatest" | "bitbar" | "browserstack" | "saucelabs" | "perfecto" | "tosca" | "aws_device_farm" | "firebase" | "kobiton" | "katalon" | "None" - Optional - since version 1.1.0
           OUTPUT_APP_NAME: "Output_app_name" - Optional - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 
 ### iOS - AUTO_DEV_SIGNING
@@ -200,5 +205,6 @@ jobs:
           BUILD_WITH_LOGS: true - Optional
           BUILD_TO_TEST: "lambdatest" | "bitbar" | "browserstack" | "saucelabs" | "perfecto" | "tosca" | "aws_device_farm" | "firebase" | "kobiton" | "katalon" | "None" - Optional - since version 1.1.0
           OUTPUT_APP_NAME: "Output_app_name" - Optional - since version 1.2.0. # Note: Since version 1.3.2, this also supports a full path.
+          UPLOAD_ARTIFACTS: false - Optional
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -120,6 +120,10 @@ inputs:
     description: 'Dynamic certificates zip file for cert pinning'
     default: "None"
     required: false
+  UPLOAD_ARTIFACTS:
+    description: "Choose if Action Upload Generated Artifacts"
+    default: true
+    required: false
 runs:
   using: "composite"
   steps:
@@ -198,6 +202,7 @@ runs:
       env:
         INPUTS_OUTPUT_APP_NAME: ${{ inputs.OUTPUT_APP_NAME }}
     - name: Upload artifacts
+      if: inputs.UPLOAD_ARTIFACTS
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}_${{ github.run_number }}_Appdome_Outputs


### PR DESCRIPTION
# Motivation
Currently, the workflow always uploads the generated artifacts. However, there are scenarios where these artifacts become obsolete and unnecessary. For example, when an application needs to be re-signed at runtime within the workflow, a new artifact is generated, rendering the initial one from this step redundant.

This change introduces an optional input UPLOAD_ARTIFACTS to prevent unnecessary artifact uploads, thus optimizing the workflow and reducing storage.

# Changes
This PR introduces the UPLOAD_ARTIFACTS input, which is now set to false by default, across all relevant sections in the README.md for both Android and iOS build processes (Private Signing, Auto Dev Signing, Auto Signing).

Additionally, the action.yml has been updated to include this new input and to conditionally execute the artifact upload step based on its value.

This provides greater flexibility and efficiency, allowing users to control whether the initial artifacts are uploaded, especially in workflows where they are subsequently replaced or not needed.