### PR TITLE
Make firebase-tools install resilient with skip and fallback

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -174,8 +174,11 @@ runs:
       shell: bash
 
     - name: Installing firebase tools
+      env:
+        FIREBASE_APP_ID: ${{ inputs.FIREBASE_APP_ID }}
       run: |
-        curl -sL firebase.tools | bash
+        chmod +x "${{ github.action_path }}/install_firebase.sh"
+        "${{ github.action_path }}/install_firebase.sh"
       shell: bash
 
     - name: permissions

--- a/action.yml
+++ b/action.yml
@@ -174,6 +174,7 @@ runs:
       shell: bash
 
     - name: Installing firebase tools
+      if: ${{ inputs.FIREBASE_APP_ID != 'None' && inputs.FIREBASE_APP_ID != '' }}
       env:
         FIREBASE_APP_ID: ${{ inputs.FIREBASE_APP_ID }}
       run: |

--- a/install_firebase.sh
+++ b/install_firebase.sh
@@ -54,7 +54,8 @@ vlog "Installing firebase-tools (needed for Crashlytics mapping upload)..."
 MAX_PRIMARY_ATTEMPTS=3
 PRIMARY_RETRY_DELAY_SEC=2
 
-for attempt in $(seq 1 "$MAX_PRIMARY_ATTEMPTS"); do
+attempt=1
+while [ "$attempt" -le "$MAX_PRIMARY_ATTEMPTS" ]; do
   vlog "Primary install attempt ${attempt}/${MAX_PRIMARY_ATTEMPTS}..."
   if run_primary_install; then
     if firebase_works; then
@@ -66,6 +67,7 @@ for attempt in $(seq 1 "$MAX_PRIMARY_ATTEMPTS"); do
     vlog "Primary install failed; retrying in ${PRIMARY_RETRY_DELAY_SEC}s..."
     sleep "$PRIMARY_RETRY_DELAY_SEC"
   fi
+  attempt=$((attempt + 1))
 done
 
 log "Primary install failed; trying GitHub Releases binary..."

--- a/install_firebase.sh
+++ b/install_firebase.sh
@@ -5,18 +5,34 @@
 #
 # Behavior:
 #   - Skips install if FIREBASE_APP_ID is not set (Crashlytics not used).
-#   - Tries the official Firebase installer first (firebase.tools).
+#   - Tries the official Firebase installer first (firebase.tools), with retries.
 #   - On failure, downloads the standalone binary from Firebase GitHub Releases.
-#   - If both fail, logs a warning and continues so Appdome fuse/sign still runs.
+#   - If both fail, logs a clear warning that mapping was NOT uploaded,
+#     but exits 0 so Appdome fuse/sign still runs.
+#
+# Logging:
+#   - Default: only key outcomes (installed / fallback / warning).
+#   - Set VERBOSE=true (or 1) for attempt/retry/download detail.
 #
 
 set -u
 
 FIREBASE_APP_ID="${FIREBASE_APP_ID:-None}"
+VERBOSE="${VERBOSE:-false}"
+
+log() {
+  echo "$1"
+}
+
+vlog() {
+  case "$VERBOSE" in
+    true|TRUE|1|yes|YES) echo "$1" ;;
+  esac
+}
 
 # Crashlytics mapping upload is optional — only needed when FIREBASE_APP_ID is provided.
 if [ -z "$FIREBASE_APP_ID" ] || [ "$FIREBASE_APP_ID" = "None" ]; then
-  echo "FIREBASE_APP_ID not provided; skipping firebase-tools install."
+  vlog "FIREBASE_APP_ID not provided; skipping firebase-tools install."
   exit 0
 fi
 
@@ -24,17 +40,35 @@ firebase_works() {
   command -v firebase >/dev/null 2>&1 && firebase --version >/dev/null 2>&1
 }
 
-echo "-- Installing firebase-tools (needed for Crashlytics mapping upload)..."
-
-# Step 1: official Firebase install script
-if curl -sL firebase.tools | bash; then
-  if firebase_works; then
-    echo "-- firebase-tools installed via firebase.tools: $(firebase --version)"
-    exit 0
+run_primary_install() {
+  if [ "$VERBOSE" = "true" ] || [ "$VERBOSE" = "TRUE" ] || [ "$VERBOSE" = "1" ]; then
+    curl -sL firebase.tools | bash
+  else
+    curl -sL firebase.tools | bash >/dev/null 2>&1
   fi
-fi
+}
 
-echo "-- Primary install failed; trying GitHub Releases binary..."
+vlog "Installing firebase-tools (needed for Crashlytics mapping upload)..."
+
+# Step 1: official Firebase install script (retry before fallback)
+MAX_PRIMARY_ATTEMPTS=3
+PRIMARY_RETRY_DELAY_SEC=2
+
+for attempt in $(seq 1 "$MAX_PRIMARY_ATTEMPTS"); do
+  vlog "Primary install attempt ${attempt}/${MAX_PRIMARY_ATTEMPTS}..."
+  if run_primary_install; then
+    if firebase_works; then
+      log "firebase-tools installed via firebase.tools: $(firebase --version)"
+      exit 0
+    fi
+  fi
+  if [ "$attempt" -lt "$MAX_PRIMARY_ATTEMPTS" ]; then
+    vlog "Primary install failed; retrying in ${PRIMARY_RETRY_DELAY_SEC}s..."
+    sleep "$PRIMARY_RETRY_DELAY_SEC"
+  fi
+done
+
+log "Primary install failed; trying GitHub Releases binary..."
 
 # Step 2: fallback — standalone binary from https://github.com/firebase/firebase-tools/releases
 UNAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -42,7 +76,7 @@ case "$UNAME" in
   linux*)  ASSET="firebase-tools-linux" ;;
   darwin*) ASSET="firebase-tools-macos" ;;
   *)
-    echo "::warning::Unsupported OS ($UNAME) for firebase-tools fallback. Continuing without firebase CLI."
+    echo "::warning::Unsupported OS ($UNAME): cannot install firebase-tools. Crashlytics mapping upload will NOT run. Appdome fuse/sign will continue."
     exit 0
     ;;
 esac
@@ -50,6 +84,7 @@ esac
 DOWNLOAD_URL="https://github.com/firebase/firebase-tools/releases/latest/download/${ASSET}"
 TMP_BIN="/tmp/firebase_standalone"
 
+vlog "Downloading $DOWNLOAD_URL ..."
 if curl -fsSL -o "$TMP_BIN" "$DOWNLOAD_URL"; then
   sudo=""
   if [ ! -w /usr/local/bin ]; then
@@ -59,13 +94,15 @@ if curl -fsSL -o "$TMP_BIN" "$DOWNLOAD_URL"; then
   $sudo chmod +rx /usr/local/bin/firebase
 
   if firebase_works; then
-    echo "-- firebase-tools installed via GitHub Releases: $(firebase --version)"
+    log "firebase-tools installed via GitHub Releases: $(firebase --version)"
     exit 0
   fi
+  vlog "Downloaded binary but firebase --version failed."
 else
-  echo "-- Failed to download $DOWNLOAD_URL"
+  vlog "Failed to download $DOWNLOAD_URL"
 fi
 
-# Step 3: do not fail the job — protection build should still complete
-echo "::warning::Could not install firebase-tools. The Appdome build will continue, but Crashlytics mapping upload may fail or be skipped."
+# Step 3: clear warning for Crashlytics path, but do not fail fuse/sign
+echo "::warning::firebase-tools install failed (official installer and GitHub Releases). Crashlytics mapping upload will NOT run. Appdome fuse/sign will continue."
+log "WARNING: firebase-tools is not available — do not assume Crashlytics deobfuscation mapping was uploaded."
 exit 0

--- a/install_firebase.sh
+++ b/install_firebase.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# Installs the Firebase CLI (firebase-tools) when Crashlytics deobfuscation
+# upload is requested via FIREBASE_APP_ID.
+#
+# Behavior:
+#   - Skips install if FIREBASE_APP_ID is not set (Crashlytics not used).
+#   - Tries the official Firebase installer first (firebase.tools).
+#   - On failure, downloads the standalone binary from Firebase GitHub Releases.
+#   - If both fail, logs a warning and continues so Appdome fuse/sign still runs.
+#
+
+set -u
+
+FIREBASE_APP_ID="${FIREBASE_APP_ID:-None}"
+
+# Crashlytics mapping upload is optional — only needed when FIREBASE_APP_ID is provided.
+if [ -z "$FIREBASE_APP_ID" ] || [ "$FIREBASE_APP_ID" = "None" ]; then
+  echo "FIREBASE_APP_ID not provided; skipping firebase-tools install."
+  exit 0
+fi
+
+firebase_works() {
+  command -v firebase >/dev/null 2>&1 && firebase --version >/dev/null 2>&1
+}
+
+echo "-- Installing firebase-tools (needed for Crashlytics mapping upload)..."
+
+# Step 1: official Firebase install script
+if curl -sL firebase.tools | bash; then
+  if firebase_works; then
+    echo "-- firebase-tools installed via firebase.tools: $(firebase --version)"
+    exit 0
+  fi
+fi
+
+echo "-- Primary install failed; trying GitHub Releases binary..."
+
+# Step 2: fallback — standalone binary from https://github.com/firebase/firebase-tools/releases
+UNAME="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$UNAME" in
+  linux*)  ASSET="firebase-tools-linux" ;;
+  darwin*) ASSET="firebase-tools-macos" ;;
+  *)
+    echo "::warning::Unsupported OS ($UNAME) for firebase-tools fallback. Continuing without firebase CLI."
+    exit 0
+    ;;
+esac
+
+DOWNLOAD_URL="https://github.com/firebase/firebase-tools/releases/latest/download/${ASSET}"
+TMP_BIN="/tmp/firebase_standalone"
+
+if curl -fsSL -o "$TMP_BIN" "$DOWNLOAD_URL"; then
+  sudo=""
+  if [ ! -w /usr/local/bin ]; then
+    sudo="sudo"
+  fi
+  $sudo mv -f "$TMP_BIN" /usr/local/bin/firebase
+  $sudo chmod +rx /usr/local/bin/firebase
+
+  if firebase_works; then
+    echo "-- firebase-tools installed via GitHub Releases: $(firebase --version)"
+    exit 0
+  fi
+else
+  echo "-- Failed to download $DOWNLOAD_URL"
+fi
+
+# Step 3: do not fail the job — protection build should still complete
+echo "::warning::Could not install firebase-tools. The Appdome build will continue, but Crashlytics mapping upload may fail or be skipped."
+exit 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes optional Crashlytics tooling and pulls binaries from external URLs; failures are non-blocking but mapping upload may be skipped without failing the job.
> 
> **Overview**
> **Firebase CLI installation** is no longer always run in the composite action. The **Installing firebase tools** step now runs only when `FIREBASE_APP_ID` is set and non-empty, and delegates to a new **`install_firebase.sh`** instead of a single `curl | bash`.
> 
> The script retries the official **firebase.tools** installer (up to 3 times), then falls back to the **firebase-tools** standalone binary from GitHub Releases on Linux/macOS. If install still fails, it emits **GitHub workflow warnings** and **exits 0** so Appdome fuse/sign continues, with an explicit note that Crashlytics deobfuscation mapping may not have been uploaded. Optional **`VERBOSE`** controls detailed install logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc037ddcf02b6c15df34072af2b1b00c764e8d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->